### PR TITLE
Fix: Install pangocairo dependencies in CI

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -24,6 +24,8 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install pangocairo dependencies
+      run: sudo apt-get update && sudo apt-get install -y libcairo2-dev libpango1.0-dev libpangocairo-1.0-0 pkg-config
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
The build was failing because manimpango, a dependency of manim, requires pangocairo >= 1.30.0. This commit updates the GitHub Actions workflow to install pangocairo and its system dependencies (libcairo2-dev, libpango1.0-dev, libpangocairo-1.0-0, pkg-config) before Python dependencies are installed.

This ensures that manimpango can be built successfully.