### PR TITLE
Fix: Resolve ModuleNotFoundError for src.manim_utils in scenes/sorts.py

### DIFF
--- a/scenes/dice.py
+++ b/scenes/dice.py
@@ -1,3 +1,9 @@
+import sys
+import os
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
 from manim import *
 import random
 from src.manim_utils import get_diceface

--- a/scenes/sorts.py
+++ b/scenes/sorts.py
@@ -1,3 +1,9 @@
+import sys
+import os
+project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+
 from manim import *
 from src.manim_utils import create_sortable_bars, animate_bar_swap
 


### PR DESCRIPTION
I modified scenes/sorts.py to programmatically add your project's root directory to sys.path. This ensures that the `src` module can be found when running this Manim script.

This addresses the ModuleNotFoundError for `src.manim_utils` by inserting the project root (parent of `src` and `scenes`) into sys.path, allowing Python's import mechanism to locate the module. This is similar to the fix I applied to scenes/dice.py.